### PR TITLE
add github actions to main: test actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,98 @@
+name: Build Android APK
+
+on:
+  pull_request:
+    branches: [ main, devel ]
+    types: [ closed ]
+
+jobs:
+  build-release:
+    name: Build Signed APK
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.base.ref == 'main' && github.event.pull_request.merged == true
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Setup Gradle cache
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Get version name
+        id: version
+        run: |
+          VERSION=$(./gradlew -q :app:printVersion | grep 'versionName=' | cut -d= -f2)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Build release APK
+        run: ./gradlew :app:assembleRelease -x validateReleaseSigning
+
+      - name: Copy APK to apk folder
+        run: |
+          mkdir -p apk
+          cp app/build/outputs/apk/release/app-release.apk apk/yt-shortless-${{ steps.version.outputs.version }}.apk
+
+      - name: Upload APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: yt-shortless-${{ steps.version.outputs.version }}
+          path: apk/yt-shortless-${{ steps.version.outputs.version }}.apk
+
+      - name: Extract changelog entry
+        id: changelog
+        run: |
+          awk "/^## \[${{ steps.version.outputs.version }}\]/{found=1; next} found && /^## \[/{exit} found{print}" CHANGELOG.md > release-notes.md
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ steps.version.outputs.version }}
+          name: v${{ steps.version.outputs.version }}
+          body_path: release-notes.md
+          files: apk/yt-shortless-${{ steps.version.outputs.version }}.apk
+
+  build-debug:
+    name: Build Debug APK
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.base.ref == 'devel' && github.event.pull_request.merged == true
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Setup Gradle cache
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Get version name
+        id: version
+        run: |
+          VERSION=$(./gradlew -q :app:printVersion | grep 'versionName=' | cut -d= -f2)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Build debug APK
+        run: ./gradlew :app:assembleDebug
+
+      - name: Copy APK to apk folder
+        run: |
+          mkdir -p apk
+          cp app/build/outputs/apk/debug/app-debug.apk apk/yt-shortless-${{ steps.version.outputs.version }}-debug.apk
+
+      - name: Upload APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: yt-shortless-${{ steps.version.outputs.version }}-debug
+          path: apk/yt-shortless-${{ steps.version.outputs.version }}-debug.apk

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on Keep a Changelog and this project follows Semantic Versio
 
 ## [Unreleased]
 
+## [1.5.1] - 2026-03-16
+### Added
+- GitHub Actions CI/CD workflow (`.github/workflows/build.yml`):
+  - Automatically builds a **release APK** and publishes a **GitHub Release** (with the changelog entry as description) when a pull request is merged into `main`.
+  - Automatically builds a **debug APK** and uploads it as a workflow artifact when a pull request is merged into `devel`.
+  - APKs are named `yt-shortless-<version>.apk` and `yt-shortless-<version>-debug.apk` respectively.
+  - Release tags (`v<version>`) are created automatically from the version defined in `gradle.properties`.
+
 ## [1.5.0] - 2026-02-28
 ### Fixed
 - Infinite-scroll stabilization in `MainActivity.kt` (`injectScrollFix`) to prevent YouTube feed scroll from getting stuck at the bottom when new content is appended.

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,4 +6,4 @@ kotlin.code.style=official
 # App versioning (Semantic Versioning)
 VERSION_MAJOR=1
 VERSION_MINOR=5
-VERSION_PATCH=0
+VERSION_PATCH=1


### PR DESCRIPTION
- GitHub Actions CI/CD workflow (`.github/workflows/build.yml`):
  - Automatically builds a **release APK** and publishes a **GitHub Release** (with the changelog entry as description) when a pull request is merged into `main`.
  - Automatically builds a **debug APK** and uploads it as a workflow artifact when a pull request is merged into `devel`.
  - APKs are named `yt-shortless-<version>.apk` and `yt-shortless-<version>-debug.apk` respectively.
  - Release tags (`v<version>`) are created automatically from the version defined in `gradle.properties`.