### PR TITLE
 GitHub Actions CI/CD workflow (`.github/workflows/build.yml`) (main)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,18 @@ jobs:
       - name: Setup Gradle cache
         uses: gradle/actions/setup-gradle@v3
 
+      - name: Decode keystore
+        run: echo "${{ secrets.RELEASE_KEYSTORE_BASE64 }}" | base64 --decode > release-keystore.jks
+
+      - name: Create keystore.properties
+        run: |
+          cat > keystore.properties << EOF
+          storeFile=../release-keystore.jks
+          storePassword=${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
+          keyAlias=${{ secrets.RELEASE_KEY_ALIAS }}
+          keyPassword=${{ secrets.RELEASE_KEY_PASSWORD }}
+          EOF
+
       - name: Get version name
         id: version
         run: |
@@ -33,13 +45,12 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Build release APK
-        run: ./gradlew :app:assembleRelease -x validateReleaseSigning
+        run: ./gradlew :app:assembleRelease
 
       - name: Copy APK to apk folder
         run: |
           mkdir -p apk
-          APK=$(find app/build/outputs/apk/release/ -name "*.apk" | head -1)
-          cp "$APK" apk/yt-shortless-${{ steps.version.outputs.version }}.apk
+          cp app/build/outputs/apk/release/app-release.apk apk/yt-shortless-${{ steps.version.outputs.version }}.apk
 
       - name: Upload APK artifact
         uses: actions/upload-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on Keep a Changelog and this project follows Semantic Versio
   - Automatically builds a **debug APK** and uploads it as a workflow artifact when a pull request is merged into `devel`.
   - APKs are named `yt-shortless-<version>.apk` and `yt-shortless-<version>-debug.apk` respectively.
   - Release tags (`v<version>`) are created automatically from the version defined in `gradle.properties`.
+  - Release APK is signed using a keystore decoded from GitHub Actions secrets (`RELEASE_KEYSTORE_BASE64`, `RELEASE_KEYSTORE_PASSWORD`, `RELEASE_KEY_ALIAS`, `RELEASE_KEY_PASSWORD`).
 
 ## [1.5.0] - 2026-02-28
 ### Fixed

--- a/keystore.properties.example
+++ b/keystore.properties.example
@@ -1,7 +1,0 @@
-# Copy this file to keystore.properties and fill real values.
-# Do not commit keystore.properties.
-
-storeFile=release-keystore.jks
-storePassword=CHANGE_ME
-keyAlias=release
-keyPassword=CHANGE_ME


### PR DESCRIPTION
 GitHub Actions CI/CD workflow (`.github/workflows/build.yml`):
  - Automatically builds a **release APK** and publishes a **GitHub Release** (with the changelog entry as description) when a pull request is merged into `main`.
  - Automatically builds a **debug APK** and uploads it as a workflow artifact when a pull request is merged into `devel`.
  - APKs are named `yt-shortless-<version>.apk` and `yt-shortless-<version>-debug.apk` respectively.
  - Release tags (`v<version>`) are created automatically from the version defined in `gradle.properties`.
  - Release APK is signed using a keystore decoded from GitHub Actions secrets (`RELEASE_KEYSTORE_BASE64`, `RELEASE_KEYSTORE_PASSWORD`, `RELEASE_KEY_ALIAS`, `RELEASE_KEY_PASSWORD`).
